### PR TITLE
ci: dispatch publish as a top-level run for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,10 @@
 name: Publish to npm
 
 on:
-  # Manual publish, with a choice of dist-tag (for prereleases etc.).
+  # The only trigger. Used both for a manual publish (with a dist-tag choice) and
+  # for the automatic publish, which release-please.yml fires via
+  # `gh workflow run` after it cuts a release. Either way this workflow is the
+  # run's entry point, which is what npm trusted publishing matches against.
   workflow_dispatch:
     inputs:
       dist_tag:
@@ -13,18 +16,6 @@ on:
           - latest
           - beta
           - next
-
-  # Called by release-please.yml right after it cuts a release, so merging the
-  # `chore(main): release X.Y.Z` PR publishes automatically. A reusable-workflow
-  # call (rather than `on: release`) is used because a Release created with the
-  # default GITHUB_TOKEN does not trigger event-based workflows.
-  workflow_call:
-    inputs:
-      dist_tag:
-        description: 'npm dist-tag to publish under'
-        type: string
-        default: latest
-        required: false
 
 jobs:
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,7 @@ name: Release Please
 
 # Maintains a "release PR" that bumps the version and updates CHANGELOG.md from
 # Conventional Commits as they land on master. Merging that PR creates the git
-# tag (vX.Y.Z) and the GitHub Release, and then publishes to npm via the publish
-# workflow (called below only when a release was actually created).
+# tag (vX.Y.Z) and the GitHub Release, then triggers the publish workflow.
 on:
   push:
     branches:
@@ -26,15 +25,20 @@ jobs:
           # from the repo root.
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Runs only when the previous job just cut a release (i.e. the release PR was
-  # merged). Calls the publish workflow as a reusable workflow so npm publishing
-  # stays defined in one place (publish.yml) and keeps OIDC trusted publishing.
-  publish:
+  # Runs only when the previous job just cut a release. It dispatches publish.yml
+  # rather than calling it as a reusable workflow, so the publish run's *entry*
+  # workflow is publish.yml itself: npm trusted publishing matches the top-level
+  # workflow, so it must be the entry, not a called sub-workflow. A GITHUB_TOKEN
+  # cannot trigger release/push events, but workflow_dispatch is the documented
+  # exception, so no PAT is needed.
+  trigger-publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/publish.yml
-    with:
-      dist_tag: latest
+      actions: write
+    steps:
+      - name: Dispatch the publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --repo "${{ github.repository }}" --ref "${{ github.ref_name }}" -f dist_tag=latest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
-      "release-as": "2.0.0",
       "changelog-sections": [
         { "type": "feat", "section": "Added" },
         { "type": "fix", "section": "Fixed" },


### PR DESCRIPTION
Fixes the auto-publish that failed with a 404 on the 2.0.0 release (the manual publish worked, 2.0.0 is on npm).

## Why it failed
npm trusted publishing matches the **entry (top-level) workflow** of the run, configured here as `publish.yml`.
- **Auto** publish called `publish.yml` as a *reusable workflow* from `release-please.yml`, so the entry workflow was `release-please.yml` → no match → 404.
- **Manual** `workflow_dispatch` had `publish.yml` as the entry → matched → published.

## The fix (no PAT needed)
- `release-please.yml` now **dispatches** `publish.yml` via `gh workflow run` once it cuts a release, instead of calling it as a reusable workflow. The publish then runs as its own top-level run with `publish.yml` as the entry, so trusted publishing matches.
- A `GITHUB_TOKEN` cannot trigger `push`/`release` events, but **`workflow_dispatch` is the documented exception**, so this works without a personal access token.
- `publish.yml` drops the now-unused `workflow_call` trigger; `workflow_dispatch` serves both manual and automatic publishes.

## Effect
Merging a `chore(master): release X.Y.Z` PR will: tag `vX.Y.Z` → create the GitHub Release → dispatch `publish.yml` → publish to npm with provenance. No npmjs.com reconfiguration needed (it stays pointed at `publish.yml`).

The same fix applies to node-cron's auto-publish wiring (its #577), which has the identical reusable-workflow issue.

---

### Also in this PR: drop the `release-as` bootstrap
`release-as: 2.0.0` forced the first release. Now that 2.0.0 is published, it is removed so future release PRs compute the version from Conventional Commits instead of repeatedly proposing 2.0.0.