### PR TITLE
feat: accept every/the prefixes on ordinal weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ every <frequency> [at <time>] [on <day>] [in <month>]
 - weekdays: `every monday`, `on friday`, `every weekday`, `every weekend`
 - day-of-month: `on day 15`, `the 15th of every month`
 - months: `in march`, `every january`
-- ordinals (node-cron `L` / `#`): `last day of the month`, `last friday of the month`, `first monday of the month`
+- ordinals (node-cron `L` / `#`): `last friday of the month`, `first monday of the month`, `last day of the month` (an `every` or `the` prefix works too)
 
 ### Values, lists, and ranges
 

--- a/src/to-cron.ts
+++ b/src/to-cron.ts
@@ -221,6 +221,11 @@ export function toCron(expression: string): string {
   function parseEvery(): void {
     i++; // consume 'every'
     const token = peek();
+    // "every last monday of the month", "every first monday", "every last day"
+    if (token in ORDINALS && (words[i + 1] in WEEKDAYS || (token === 'last' && words[i + 1] === 'day'))) {
+      parseOrdinalWeekday();
+      return;
+    }
     if (token === 'other') { i++; everyInterval(words[i++], 2); return; }
     if (isNumber(token)) { const n = Number(token); i++; everyInterval(words[i++], n); return; }
     if (UNITS.has(token)) { i++; everyUnit(token); return; }
@@ -313,7 +318,11 @@ export function toCron(expression: string): string {
     else if (token === 'on') parseOn();
     else if (token === 'in') parseIn();
     else if (token in WEEKDAYS) set('dow', readValues(DOW));
-    else if (token === 'the' || ordinalDay(token) !== null) {
+    else if (token === 'the' && words[i + 1] in ORDINALS
+      && (words[i + 2] in WEEKDAYS || (words[i + 1] === 'last' && words[i + 2] === 'day'))) {
+      i++; // consume 'the' before "last monday of the month"
+      parseOrdinalWeekday();
+    } else if (token === 'the' || ordinalDay(token) !== null) {
       if (token === 'the') i++;
       set('dom', readValues(FIELDS.day));
       consumeOfTheMonth();

--- a/test/golden.test.ts
+++ b/test/golden.test.ts
@@ -103,6 +103,13 @@ describe('toCron — ordinals (L / #)', () => {
     ['last day of the month', '0 0 0 L * *'],
     ['last friday of the month', '0 0 0 * * 5L'],
     ['first monday of the month at 9am', '0 0 9 * * 1#1'],
+    // "every" / "the" prefixes on ordinal weekdays
+    ['every last monday of the month', '0 0 0 * * 1L'],
+    ['the last monday of the month', '0 0 0 * * 1L'],
+    ['every first monday of the month', '0 0 0 * * 1#1'],
+    ['every second tuesday of the month', '0 0 0 * * 2#2'],
+    ['every last day of the month', '0 0 0 L * *'],
+    ['the last day of the month', '0 0 0 L * *'],
   ]);
 });
 


### PR DESCRIPTION
`every last monday of the month` and `the last monday of the month` previously threw a `CronTranslateError`, even though the bare `last monday of the month` worked. The `every` / `the` prefixes are natural phrasings, so this was a usability gap, not a deliberate scope cut.

## Fix
`parseEvery` and the `the`-clause now delegate to the ordinal-weekday handler when they see an ordinal word followed by a weekday (or `last day`):

| Input | Cron |
|---|---|
| `every last monday of the month` | `0 0 0 * * 1L` |
| `the last monday of the month` | `0 0 0 * * 1L` |
| `every first monday of the month` | `0 0 0 * * 1#1` |
| `every second tuesday of the month` | `0 0 0 * * 2#2` |
| `every last day of the month` | `0 0 0 L * *` |

`every second` stays the unit (the ordinal path requires a following weekday).

## Checks
- typecheck, lint, build clean; 148 tests green (6 new golden cases). README note added.