### PR TITLE
docs: add 1.0.0 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,10 @@
 ### Added
 
 * release the TypeScript rewrite as 2.0.0 ([3c90562](https://github.com/node-cron/cron-translate/commit/3c9056230de34ef512b6a8cae9882ee922b0556a))
+
+## 1.0.0 (2018-10-05)
+
+
+### Added
+
+* initial release: translate English expressions into cron via the every/on/from operators ([522dcae](https://github.com/node-cron/cron-translate/commit/522dcaea10595dcb3407f31f0b8603f4d4098340))


### PR DESCRIPTION
Backfills the changelog entry for `1.0.0` (the original release, published to npm on 2018-10-05).

Completes the retroactive documentation of `1.0.0`, alongside the now-created `v1.0.0` git tag (at `522dcae`) and GitHub Release. This also makes the existing `compare/v1.0.0...v2.0.0` link in the `2.0.0` entry resolve.